### PR TITLE
Fix date abbreviation check

### DIFF
--- a/js/date.js
+++ b/js/date.js
@@ -25,7 +25,7 @@ var date = (function() {
       var time = _makeTimeObject();
       time.day = helper.day(time.day);
       time.month = helper.month(time.month);
-      if (state.get().header.date.character.length == "short") {
+      if (state.get().header.date.character == "short") {
         time.day = time.day.substring(0, 3);
         time.month = time.month.substring(0, 3);
       };


### PR DESCRIPTION
## Summary
- correct date abbreviation logic by checking value instead of string length

## Testing
- `node --check js/date.js`


------
https://chatgpt.com/codex/tasks/task_e_688e5c5e8d788320a6f4a0f91a9dbd74